### PR TITLE
Converted the stencil to a compiled function using autowrap

### DIFF
--- a/AcousticFWI/Acoustic-wave-equation.ipynb
+++ b/AcousticFWI/Acoustic-wave-equation.ipynb
@@ -14,6 +14,7 @@
     "import numpy as np\n",
     "from numpy import linalg as LA\n",
     "from __future__ import print_function\n",
+    "from sympy.utilities.autowrap import binary_function\n",
     "init_printing()"
    ]
   },
@@ -46,7 +47,8 @@
     "p=Function('p')\n",
     "m,s,h = symbols('m s h')\n",
     "m=M(x,y)\n",
-    "q=Q(x,y,t)"
+    "q=Q(x,y,t)\n",
+    "tb, tf, xb, xf, yb, yf, c, m_var, q_var = symbols('tb tf xb xf yb yf c mv qv')"
    ]
   },
   {
@@ -75,7 +77,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABbIAAAAyBAMAAAB7QzDBAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAiUSZq1TvELvdZiIy\nds1Wk1T5AAAOZElEQVR4Ae1ce4hcVxn/ZrKzMzuzrxLRVkkzBf/x0e5KowbUdAWxVm27IK3GB7u2\nYgnadgqlVKXdlZZaW0sStMVS2g4Iio/aQWmJD8iA4B+CZkKLFSVksRYt6naNhqRNk/U7j+887j3n\nzn3Mgd3NnD/u/c7j+53f9zvf3Ll39twFwFJq4mFYhgpsDQWqcyqO7coaGkMFNr8Cl1EIpTmyhueh\nAltAgfqKDOL6lhXNz3d/y6pnrfw9q0PK8aFwoWjAEIwZTNpLk1KpVMMal9/fTTXQN2gDR/11wbl6\ng8Ud71J2Nq2WbJVDp7KNTzs6FC4UDRiCMYPG/nCZfTuUTqTV3jVuI0d9xzxnXJu1iI+0YHTRaslU\nuXNXmMwOhQtQMGAIx6x6z7XhMvtKgC9mWll78IaOurLIyS7Y6o0egJHX7Sgy1SbCZDaEwoWiAYdj\nBnDcXptMC9Fn8D6Aa7t9xiR1B1uPQUR9kDP/ts1/8tR5ltlFA96kmf1Kawtn9kIHk7p+xs5srI0V\nueyG+iyHwmXRFwp4k2Y2hv1kkW+EgOtR/JtqbJat6jIe7DIzbdcz1UJFHAqXBVco4E2b2eX/ZFrY\nyOCA61E8s+vs2nykGaEM8N1YS4aGUBGHwmWhFQp402a245q2AdYZKRTP7OpZhHlPLJpty7GmDA2h\nMjAULoZWLOBNm9m7M6xqfGjA9Sie2bCKhL8QI/18rCVLQ6iIQ+FibMUC3qyZPTGXZVljYwOuxwAy\n+3gHxl+Lcq7Mwq+ibRnqoSIOhQtQMODNmtmfgAb7BSFvCbceA7gbgcM9mIj9NPIbgL/kDRf9QkUc\nChegYMDBIkYxB3D18i3l+CxMbN3MHl2G2mIk9MbBC3YdiLRlqYbKwFC4UDTgTZrZv7hg+1VZ1jU6\nNth6DOTzjGmNyW2XyfX1dTOzf2d3G7V616iQue3Dr36UbDyPt41KSnPQuE48zSUaMPgj/on20lYk\n4gR37ROz3Bx33fqdtjE0k5huRI32yvr6q7oGCbSdSNGoM3GjeZ3IMIioS2dgaZamcZ8by+521vpx\nfxf1HCIjy3nQuCnwDHoJEY90jXEe03S/c59nULw5DUcUc8CImodJW7cKKyW3qBtA9T7zGhnvT5NB\nYKdQPwEk1/oJmOk5JjSavPsov9KBSWOcx8y+1XHQuOnwDPq+iKuPAawY4zym5f6iZ1CkOSVHJuZg\nETUPi7ZuBsjAzXQT9mTSdTMfcpIAGnH8LCzMx/mYLUfNimkv4MPitGz4mtlh2mqE2ei0qx3ZPCBc\nJ55z5mijL+LKGgD1KfSosx7Ce06qfq9EbESqmIXcORAVhySDIouNycAt5gtTKrsciuVDVgIkIlb/\nC8e7cT5my5fMimnvwS+bRdnwObPDtEcpX81Gp13pyeYB4TrxnDNHG30Rb1sBuEMOVuhRZwDTvaw3\n4HglYgipYgYmZh7EOEdHi0nb6k7PzXITlZkWNToUy4WsBUhG/B9ckZx75QNELXo+iA0vyUbvsr0t\n6uWtK54DwnXieWc3OrwRj00DTM6LkQrdcBSm5V7S6nklYm6pYgYmZh5EQSz5aNG2hqbnZrmJykWq\nzaFYLmQtQDLi6YTMvuTB3z/fKs0it7ue/9nRHud42wegcROzyh85fTUAvRrsWLbyhb8+diUf4PDm\nWOKw489dbkiehXET8Yx5XaaKuHrsY5fu4COq23vwbIuZb91/bw+4HFhxqAqg3LknO0y++6kHZUVK\npJEhvZagxYwj9l8dRcdtKNqam46673oY3PRCq4le/PSfOqJCiuWKWjMzJE1GvAX8b21MXzVfWq61\n8aZjuv742AonOH09TKxxq8JOP+UmgCOzSyMPw4XwgMdb+uHad+UrPcSzIG4ynprWbaiIb4Mf9p7g\nY0r4esZxMRpvC6G+ImxiK2ryqNxV69I/4UOyIiXSyJBeS1BiQhyx/+ooOm5D0dbcjKj7rYfmZhCh\niarnOiNzokKK5YpaMzMESEbcB9cSi+i5Mf83qK+NzeM3YKt0qsI/eo35PVBb5iPZXSfs5aYzs5+Z\nnIOn4WGPt/QDOAzjLV4hngVxk/HUtE5DR/wm2Nn6DB/zDPK5X4zG20KoHBA2sRU1cdTuqnWhS870\n4dfIGbQEJSbEEfuvjqLjNDRtzc2Iut96aG6aiJqn8jqlC33L5YtaMzMEkGvgQXxEZvbdj7LyLwD8\nM40sVTgJpVOjTbzqwuSyIFuFm2Gqx2121wlHRDMtm+ENLXws3tnCl4ed3tWX2XxPdGHpxqbAoFwp\nhtsHT9JFUjT/FIW7vr6mI27BP+TQ1mgPzgqb3RaOrwmb2BoRr2t3hY4fhpslkLxma+T0Wq5rMdmz\nZgTRqa+lomSQL2oLib6btWgGN00EKJ3wY4H68SIVyxe1Vs0QIBnxEbiipQKPGPgUWltkmQ2UzfzR\n/EiXtcBSEw88sy9eXX1kdTX2MyM+Ft8HmNlOb9bMS3n/aTyXVldfvmV1dRbNgrgJeGLCpKMRscxm\nfCmhNS7eCq2yN715ZhtsLTTDXbYfhAZ3NiVSyDg8rZbIQorpQpySycN+OIkhWgydFYO24qai7r8e\nmptOE5oHPxaHu1gxFHNxNOUhV3ZWUQNdXdjDNpe0DyLAo7CzY2KZNj6FLs2yuxHM4C60eBd+CP8o\nxszgxZg/rbMqfZZFlzheBPibIt6NOL1pYGO+ivsNWaGrYDHcPng0reesI8ZsxvBY2QMTi9wor6EG\n9BMCseU9dNDusgU/DKVFiUMSaeQMWgKJ6ULsuzrEz3PWtDU3FTX0XQ/FzVhomgkvU2+UmUOK5Yka\nryi0HoYAyYj73L9nb78HExn/fvT9FnuCrLSOw4TI7Noc3CtoXwyf9T1Bcm/8Y1n9JvYE6fSm0CcX\nYUrYxLMYbh88mjZ2Lu1+L7apiD+Jj8kviEH3AsbMSmml0vU+QdqC8fF4qK/B6PQPRE1mtoGcSkuw\nxXQgOvW1VCQ6sXOKqMFCoo+nRLK5GURopqcBPl8XmUPrmydq0KoZAiQj3gJPN4mGPpc6Iyt4E7E8\n/mUozeGXwvx++CVUz+GAbcvl14S1q9oDuFz6WBELbzgNv+3CGzze0g9qXTgmbOJZDNeLx9nTrPHz\nW+AabKSIyydra402LK1g226YEda2ubsw/lnhS2xFDSKCyVZAFaea06ImJDKRuZZ8Dn/MElmJGUdM\nXh0OT3Ri5xRRQ3puRprQTCjqiZKokGJpMigataGaIUAy4mlYaBINfR7rjJ/BlLzkuQ7/+r392F1v\nbos3nasffA57nsSP4SGWkX+VPmLZZEV4l0/seB+/XXF6y6HQOPbUvLCJZzFcPx7j7C+PwZGOjrh6\n9QtHfyTfaL99B/4ti73b3nioh1f1psAgthIxIhjNg194pXfJipDIROZa8rfm/TFDRMw4Ijj1JcTk\nl/JTRJ2wzlFuBhES4AH8k8e0qJBiaTIoimyoZgiQiIh3wjO4XtEy2mzg49JFvPkx1VnGtcer1go+\nR3ILF3uRtWCxMlt4490bljE5knxMb9avC/FkLYPAjeIRZz2jsMR2tBvgcDMe8Tv4kD14FBbAs8JJ\nPRXIzXduweRYcbIkknhMDUKOx8x3tbnF5JA2omd1CN7igr+S3MeWJ23Umbh5hNbrYeZAJmSllQgm\nERF3RLl3sVbwIvUiB/ie0qSO1jX8WZlZrJR64gxvl2d5Yt54z4qlzo/cwoPtzVp1Kbe1PQjcKB5x\n1rNISxCFhVY8YqQ0ssJ/E0GLlx3ybKALmVyCybHiZEvUxkahBrNYccSskaNicg8bkcVn68sR23xo\n/JAp6kzcPEKTYg6OjJ0OJiHqthVHImLlJIyuWMNlZawHVbGpqtah/q+i8Tg8hEdmsXK3OMWO6A1L\n87z5QeqMe1NP/DxoXIZHnGOzTQmij+OFLBJxtY1fOr0aBsMsVqoreIgU4eQSLDLQqHI8riUhu7RU\nyDExDSgy4/qyqBU8DaNzlqizcfMKLabum0H+qD3BOBHxzYPaGgVrnnFDyN5zuKR4Z7BM7W00Ln2u\ni0dmsaLSVlTVEb0rT/6bVw9RYxsN25t64udB4zK8dnwa0YI/mmIpzcYjZlef8rH345GuQ/pjznx4\nwd9nWXEJxjucB47H1SBkh5YaOSamA7SNbba+LGoFH/XIEnU2boxIQolztAcnRO0Jxok4suZ+iU/f\nRAD+KuIr9Y67x/TGnxgyl0Hj+vAEMfE4oW+6kiL+cTwW8TxhhuwXLO6tWhwc48iZxHQgqtnokSJd\n1A6kgtyIyOCRCXF0GcbF1Z/mAmCb5S6Bd+qGTFYxb/9UoXDx5pptRytPl7v+yZN6xOa7/IL5scMh\n45xbPWr8rwzR/6TDNsuNv3TdN/yKJ/UU8/Yjh8LFO1G+He0P132K35T4Gfh6+Oa7/IL5YLE9HPJ5\nEDX7y/YVtrhss9wobg+yW9PWinn7ZwmFiw8EfDvarevr/skTe/jmu/yCJWCHQz4Pov4mCjvTtNRV\nm++s1rSVYt7+WULh8t/naTuaf/qEnj16813CqDxd4ZDPg6jPouL8Xw1r5cVmOV3PZhXz9s8VChfD\nl9vR/HMn99Dmu+RReXrDIW/9qPl/GeYHpbzeLKeaMhjFvP0ThcLFGZf0djT//P4eY++Zf1CunnDI\nSGerR42vvWC5kR2oTKrNd9SS5VzM2z9TKFyc0diO5p/f31M3tvP5R+XpCYeMbLZ61DP4AIn/7ML8\nVaCmNt/lWY1i3v4ZQ+HijNfo7Wj++f09I8Z2Pv+oPD3hkJHNVo/6Hq745KwhvN4sZzSmNot5+6cJ\nhYszPqC3o/nn9/fUjO18/lF5esIhI5stHnXlJq64eKEpj/hDn6ECG1KBO5qC1t4NyW5IaqhAXgXE\nzQj+uDmXF2HoN1RgAypQXyZSV5MxPA8V2AIKXKZi2NZU5tAYKrDZFaheySL4P39PdLTEFCkbAAAA\nAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABbIAAAAyBAMAAAB7QzDBAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAiUSZq1TvELvdZiIy\nds1Wk1T5AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAOZElEQVR4Ae1ce4hcVxn/ZrKzMzuzrxLRVkkz\nBf/x0e5KowbUdAWxVm27IK3GB7u2YgnadgqlVKXdlZZaW0sStMVS2g4Iio/aQWmJD8iA4B+CZkKL\nFSVksRYt6naNhqRNk/U7j+887j3nzn3Mgd3NnD/u/c7j+53f9zvf3Ll39twFwFJq4mFYhgpsDQWq\ncyqO7coaGkMFNr8Cl1EIpTmyhuehAltAgfqKDOL6lhXNz3d/y6pnrfw9q0PK8aFwoWjAEIwZTNpL\nk1KpVMMal9/fTTXQN2gDR/11wbl6g8Ud71J2Nq2WbJVDp7KNTzs6FC4UDRiCMYPG/nCZfTuUTqTV\n3jVuI0d9xzxnXJu1iI+0YHTRaslUuXNXmMwOhQtQMGAIx6x6z7XhMvtKgC9mWll78IaOurLIyS7Y\n6o0egJHX7Sgy1SbCZDaEwoWiAYdjBnDcXptMC9Fn8D6Aa7t9xiR1B1uPQUR9kDP/ts1/8tR5ltlF\nA96kmf1Kawtn9kIHk7p+xs5srI0VueyG+iyHwmXRFwp4k2Y2hv1kkW+EgOtR/JtqbJat6jIe7DIz\nbdcz1UJFHAqXBVco4E2b2eX/ZFrYyOCA61E8s+vs2nykGaEM8N1YS4aGUBGHwmWhFQp402a245q2\nAdYZKRTP7OpZhHlPLJpty7GmDA2hMjAULoZWLOBNm9m7M6xqfGjA9Sie2bCKhL8QI/18rCVLQ6iI\nQ+FibMUC3qyZPTGXZVljYwOuxwAy+3gHxl+Lcq7Mwq+ibRnqoSIOhQtQMODNmtmfgAb7BSFvCbce\nA7gbgcM9mIj9NPIbgL/kDRf9QkUcChegYMDBIkYxB3D18i3l+CxMbN3MHl2G2mIk9MbBC3YdiLRl\nqYbKwFC4UDTgTZrZv7hg+1VZ1jU6Nth6DOTzjGmNyW2XyfX1dTOzf2d3G7V616iQue3Dr36UbDyP\nt41KSnPQuE48zSUaMPgj/on20lYk4gR37ROz3Bx33fqdtjE0k5huRI32yvr6q7oGCbSdSNGoM3Gj\neZ3IMIioS2dgaZamcZ8by+521vpxfxf1HCIjy3nQuCnwDHoJEY90jXEe03S/c59nULw5DUcUc8CI\nmodJW7cKKyW3qBtA9T7zGhnvT5NBYKdQPwEk1/oJmOk5JjSavPsov9KBSWOcx8y+1XHQuOnwDPq+\niKuPAawY4zym5f6iZ1CkOSVHJuZgETUPi7ZuBsjAzXQT9mTSdTMfcpIAGnH8LCzMx/mYLUfNimkv\n4MPitGz4mtlh2mqE2ei0qx3ZPCBcJ55z5mijL+LKGgD1KfSosx7Ce06qfq9EbESqmIXcORAVhySD\nIouNycAt5gtTKrsciuVDVgIkIlb/C8e7cT5my5fMimnvwS+bRdnwObPDtEcpX81Gp13pyeYB4Trx\nnDNHG30Rb1sBuEMOVuhRZwDTvaw34HglYgipYgYmZh7EOEdHi0nb6k7PzXITlZkWNToUy4WsBUhG\n/B9ckZx75QNELXo+iA0vyUbvsr0t6uWtK54DwnXieWc3OrwRj00DTM6LkQrdcBSm5V7S6nklYm6p\nYgYmZh5EQSz5aNG2hqbnZrmJykWqzaFYLmQtQDLi6YTMvuTB3z/fKs0it7ue/9nRHud42wegcROz\nyh85fTUAvRrsWLbyhb8+diUf4PDmWOKw489dbkiehXET8Yx5XaaKuHrsY5fu4COq23vwbIuZb91/\nbw+4HFhxqAqg3LknO0y++6kHZUVKpJEhvZagxYwj9l8dRcdtKNqam46673oY3PRCq4le/PSfOqJC\niuWKWjMzJE1GvAX8b21MXzVfWq618aZjuv742AonOH09TKxxq8JOP+UmgCOzSyMPw4XwgMdb+uHa\nd+UrPcSzIG4ynprWbaiIb4Mf9p7gY0r4esZxMRpvC6G+ImxiK2ryqNxV69I/4UOyIiXSyJBeS1Bi\nQhyx/+ooOm5D0dbcjKj7rYfmZhChiarnOiNzokKK5YpaMzMESEbcB9cSi+i5Mf83qK+NzeM3YKt0\nqsI/eo35PVBb5iPZXSfs5aYzs5+ZnIOn4WGPt/QDOAzjLV4hngVxk/HUtE5DR/wm2Nn6DB/zDPK5\nX4zG20KoHBA2sRU1cdTuqnWhS8704dfIGbQEJSbEEfuvjqLjNDRtzc2Iut96aG6aiJqn8jqlC33L\n5YtaMzMEkGvgQXxEZvbdj7LyLwD8M40sVTgJpVOjTbzqwuSyIFuFm2Gqx2121wlHRDMtm+ENLXws\n3tnCl4ed3tWX2XxPdGHpxqbAoFwphtsHT9JFUjT/FIW7vr6mI27BP+TQ1mgPzgqb3RaOrwmb2BoR\nr2t3hY4fhpslkLxma+T0Wq5rMdmzZgTRqa+lomSQL2oLib6btWgGN00EKJ3wY4H68SIVyxe1Vs0Q\nIBnxEbiipQKPGPgUWltkmQ2UzfzR/EiXtcBSEw88sy9eXX1kdTX2MyM+Ft8HmNlOb9bMS3n/aTyX\nVldfvmV1dRbNgrgJeGLCpKMRscxmfCmhNS7eCq2yN715ZhtsLTTDXbYfhAZ3NiVSyDg8rZbIQorp\nQpySycN+OIkhWgydFYO24qai7r8emptOE5oHPxaHu1gxFHNxNOUhV3ZWUQNdXdjDNpe0DyLAo7Cz\nY2KZNj6FLs2yuxHM4C60eBd+CP8oxszgxZg/rbMqfZZFlzheBPibIt6NOL1pYGO+ivsNWaGrYDHc\nPng0reesI8ZsxvBY2QMTi9wor6EG9BMCseU9dNDusgU/DKVFiUMSaeQMWgKJ6ULsuzrEz3PWtDU3\nFTX0XQ/FzVhomgkvU2+UmUOK5Ykaryi0HoYAyYj73L9nb78HExn/fvT9FnuCrLSOw4TI7Noc3Cto\nXwyf9T1Bcm/8Y1n9JvYE6fSm0CcXYUrYxLMYbh88mjZ2Lu1+L7apiD+Jj8kviEH3AsbMSmml0vU+\nQdqC8fF4qK/B6PQPRE1mtoGcSkuwxXQgOvW1VCQ6sXOKqMFCoo+nRLK5GURopqcBPl8XmUPrmydq\n0KoZAiQj3gJPN4mGPpc6Iyt4E7E8/mUozeGXwvx++CVUz+GAbcvl14S1q9oDuFz6WBELbzgNv+3C\nGzze0g9qXTgmbOJZDNeLx9nTrPHzW+AabKSIyydra402LK1g226YEda2ubsw/lnhS2xFDSKCyVZA\nFaea06ImJDKRuZZ8Dn/MElmJGUdMXh0OT3Ri5xRRQ3puRprQTCjqiZKokGJpMigataGaIUAy4mlY\naBINfR7rjJ/BlLzkuQ7/+r392F1vbos3nasffA57nsSP4SGWkX+VPmLZZEV4l0/seB+/XXF6y6HQ\nOPbUvLCJZzFcPx7j7C+PwZGOjrh69QtHfyTfaL99B/4ti73b3nioh1f1psAgthIxIhjNg194pXfJ\nipDIROZa8rfm/TFDRMw4Ijj1JcTkl/JTRJ2wzlFuBhES4AH8k8e0qJBiaTIoimyoZgiQiIh3wjO4\nXtEy2mzg49JFvPkx1VnGtcer1go+R3ILF3uRtWCxMlt4490bljE5knxMb9avC/FkLYPAjeIRZz2j\nsMR2tBvgcDMe8Tv4kD14FBbAs8JJPRXIzXduweRYcbIkknhMDUKOx8x3tbnF5JA2omd1CN7igr+S\n3MeWJ23Umbh5hNbrYeZAJmSllQgmERF3RLl3sVbwIvUiB/ie0qSO1jX8WZlZrJR64gxvl2d5Yt54\nz4qlzo/cwoPtzVp1Kbe1PQjcKB5x1rNISxCFhVY8YqQ0ssJ/E0GLlx3ybKALmVyCybHiZEvUxkah\nBrNYccSskaNicg8bkcVn68sR23xo/JAp6kzcPEKTYg6OjJ0OJiHqthVHImLlJIyuWMNlZawHVbGp\nqtah/q+i8Tg8hEdmsXK3OMWO6A1L87z5QeqMe1NP/DxoXIZHnGOzTQmij+OFLBJxtY1fOr0aBsMs\nVqoreIgU4eQSLDLQqHI8riUhu7RUyDExDSgy4/qyqBU8DaNzlqizcfMKLabum0H+qD3BOBHxzYPa\nGgVrnnFDyN5zuKR4Z7BM7W00Ln2ui0dmsaLSVlTVEb0rT/6bVw9RYxsN25t64udB4zK8dnwa0YI/\nmmIpzcYjZlef8rH345GuQ/pjznx4wd9nWXEJxjucB47H1SBkh5YaOSamA7SNbba+LGoFH/XIEnU2\nboxIQolztAcnRO0Jxok4suZ+iU/fRAD+KuIr9Y67x/TGnxgyl0Hj+vAEMfE4oW+6kiL+cTwW8Txh\nhuwXLO6tWhwc48iZxHQgqtnokSJd1A6kgtyIyOCRCXF0GcbF1Z/mAmCb5S6Bd+qGTFYxb/9UoXDx\n5pptRytPl7v+yZN6xOa7/IL5scMh45xbPWr8rwzR/6TDNsuNv3TdN/yKJ/UU8/Yjh8LFO1G+He0P\n132K35T4Gfh6+Oa7/IL5YLE9HPJ5EDX7y/YVtrhss9wobg+yW9PWinn7ZwmFiw8EfDvarevr/skT\ne/jmu/yCJWCHQz4Pov4mCjvTtNRVm++s1rSVYt7+WULh8t/naTuaf/qEnj16813CqDxd4ZDPg6jP\nouL8Xw1r5cVmOV3PZhXz9s8VChfDl9vR/HMn99Dmu+RReXrDIW/9qPl/GeYHpbzeLKeaMhjFvP0T\nhcLFGZf0djT//P4eY++Zf1CunnDISGerR42vvWC5kR2oTKrNd9SS5VzM2z9TKFyc0diO5p/f31M3\ntvP5R+XpCYeMbLZ61DP4AIn/7ML8VaCmNt/lWY1i3v4ZQ+HijNfo7Wj++f09I8Z2Pv+oPD3hkJHN\nVo/6Hq745KwhvN4sZzSmNot5+6cJhYszPqC3o/nn9/fUjO18/lF5esIhI5stHnXlJq64eKEpj/hD\nn6ECG1KBO5qC1t4NyW5IaqhAXgXEzQj+uDmXF2HoN1RgAypQXyZSV5MxPA8V2AIKXKZi2NZU5tAY\nKrDZFaheySL4P39PdLTEFCkbAAAAAElFTkSuQmCC\n",
       "text/latex": [
        "$$\\left ( - \\frac{2}{s^{2}} p{\\left (x,y,t \\right )} + \\frac{1}{s^{2}} p{\\left (x,y,- s + t \\right )} + \\frac{1}{s^{2}} p{\\left (x,y,s + t \\right )}, \\quad - \\frac{2}{h^{2}} p{\\left (x,y,t \\right )} + \\frac{1}{h^{2}} p{\\left (- h + x,y,t \\right )} + \\frac{1}{h^{2}} p{\\left (h + x,y,t \\right )}, \\quad - \\frac{2}{h^{2}} p{\\left (x,y,t \\right )} + \\frac{1}{h^{2}} p{\\left (x,- h + y,t \\right )} + \\frac{1}{h^{2}} p{\\left (x,h + y,t \\right )}\\right )$$"
       ],
@@ -132,7 +134,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABbMAAAAyBAMAAACUgVv/AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAEM3dMiK7mat272ZU\niUTExn7MAAAQ40lEQVR4Ae1da4xkRRU+3TPdM9Ov6ayR7GrI9A4oaIgZMagQCK1/fP3Y/oEYAd3W\n8FxitiWKK1F3QDQ8YraJDxiQbOODhURhWF0V/bGNgAlIMiNE1tWQ7UQxEkNmFhaUh4yn3lW3qnrq\n3r69GTJzE+49deqc73x1zpnbt+/ULABJjnIvideGz1AzsHmo6OsF/NB6WeibaZ2V2puJ7RrlWp5d\no8TWN63963v5MVa/1Wv7eDUyNdqKKOINs1G8eO59rIeA7E9LHx5BU4Mi5xeDwvQ1+tTVF/ed7zM5\nKH0H9BDKR6Kcf9QRi6oy90VnRppRTZxxbuewWnsIyP60xFmyy3Zg5MzPXLCxdJlZONKL5SGNB6Yv\nkaQwhPIR7BN2eVs7b92jb29KOvGFzGV7htTaQ0Duk5b4Kzc8UkB+3ABMMhivQqGTxLFfvyTCQ6ch\nlI9RmfC29kK0E3P7m0npU7+9UcCB0HTn9JH9adHjJpEHRx5ZTBJX9ynMwPgxXREuD07fjpV++WgM\nP9UPRDmUs82oKtZ4SCtADukj+9MSa8kO48GRSy85YGOpskfXdWsXrQQe2GjtWA3kNh68tcG66bgj\n9dWOeD+t+7pBCvStAOnfmWgIL9WRZoRCpr3R2pGUJBl6Ex4OdjCFJ7ulhE81KdC3Fnq8W3tbL0Kh\nDButHUlJkmEKvTHVThLY9Hm/OQwepUDfinW8W/uaKINHNlo7mpIk4xR6I1tLEtjwGWsaw/BBCvSt\nYMe7te+JMMgsbrR2JCWJhin0xoT1NSg2k9tie3CHFOhboY9za4++FmFQuuGGPfcM9Ek4pBUgz/SR\nh1FBltAUkHOvRGoTe1hqwSdjO1GHFOhbgdMvX1+qrjtDoWmxiqMY0gqQQvrIw6ggy1UayHfHSbvL\n9iMA33fpV9elQT8aJf3y0Qg+qvlOlADAZNPWxdAMaQXIIH1kX1piLNdjmgbyDg92qDp3zjO7ZkKN\nTbs06JuIwygfiTB204s3RyPRseMOXd7533nN9hOabIrFujlmo133f1B3H9UHLnun7pcubQQZ/Mwc\n3k7EaFpiIYog6SOLxB5piBj61U9S+Anr7MrKyowY4DXcM5KYJEWMkoFI+fxkNMZcdKbYNjM1Uy1z\nbI1yTUslFddLyS+c75w64cdOtVSO16XoFUxmaSOuhqdohXINRwSe2IM9FQUgd+iZm3FsLls3AOFn\nKuUouae7iBLYLfTvjn5kLLyQFFtOS21LZSq8OxHf0oCsaeocbXVq4RS3mmozZwDU+szzqQiztBH7\n4SlycbiGIYJK7DajOE/WYRzTElm2oqL8lM6Qknt6imigm4PkZEwcHAWm2PJb6FoqU3GnOVSjBYCJ\nRT58q1JHJGkS0b8ux7ZvaRlAhM00pGFUECZcnzaixOtDASAOV4kI9pq1xanEGh+pm5pY5X0qM5oH\nE5WfNcUUkYQpK+npWaqviApBSmJlEtK3Vi8ZC0pPsZwMEPbWVzH6qW/+Ksx0h08+5jOCgrs1K2pr\ng+07VgN4G0cstb3QJrO0ERVeHwr4JSacq0IEe83aKlViJ2c19UlE3gNgLlszUH6aUhdX9/Qs1VNE\nHVvIYmWKjNAIC371kpF2wlFPsZwMEHa7W096VmakGBHOwfFpXCdYRExw+HdbRTRlBWv7kt2c2S5z\n9CQbJyPM0kZUeH4KyCIGV4XYv7VVYvVXVeU3SEKO1CPLJkp+KD+hMa8Bnp6leopowrORqKYiIzSm\ntZ+MtBOOeorlZIDQp7Wfv+Rjt1XLLQTZcttn72xTsBO/Crm7iFT59ss3Aog/GBYsqA0/VZ4+b+5a\napGZ+9Zzh/Up7NyvPXgJ13BfiQz/2nl5G2hctHAmWzLTkG3EzKE2XFAlUWIgclI6Q0FBBUuG7GAo\nE6MQ9cQWapIObKfy7l5YQZQflVwJkwnXIoqlSndXERVXaQaH76izAaumBmn/GEsyrr7Cu94cfx/C\nG8Monoq4urSH1t5pt/jNbrmZn8fnjsXimSM1arP4OEwsU4k8AcF+KoJNH/Xl8bPhabgSpRPhF+3T\nuSW/TL0DbuAiX4FCBnxOg2KNTVvJJmrJTEO2EculDuxlKOGIzB7PCk9QUMGSIStEkS8nopbYwoyk\nA0ewEAA762EFUX5UciVMJVxFFEuV7q4iaqsXdtl6vsVkXk0FKdYqTLXqOfsKTobLDCijHRTK6hI+\nvHmOXPdUKC6PdLFJq+WjpQYxy3WvgnyTSPQhEx6moru1L8rOwkE4Gy3+BEeqj3JLflmow6WGr4YM\n+JwGJV5VK9k4p5hpyBYiXIQPaTxIOCInBaDwBAUVLBmyQhTldiIia+CJHelIOnAuLcCrEFYQ5Uck\nV8K0hKuIYqnS3VVEbfXCbjuMVpnMW1tBirUKU42Ms69yy/AhA0q0w6b3keNkmMSX9asdFIC1tnAD\nzScDr0P5aKGHd225YSoD98JkmzqSJyDYRkXV2lrY5epkF1ua/E1xFd7J7TInEXqn1wndew1fDRnI\nc9roMpsWydaRFTOFbCNCtdAGvgsjHNHBUFBQwVZBdmfRxVAmRkPUEktaW5RmheSj9AqsWhDhoDK2\n7EqYlnAVkS1V83QVUXGVyZra1yP08OCtrSC5RjWWIuPsq8yr32BIAspoBz4VdNld9ZrhN/p8h2QS\nf/Xe5lao21an8lQPL7S1n5yePmt62n5pu1SFHcD+XN7a53MO5I4RGOWrkDPkCxNt7fL09Ek/mp5u\nEUv90JhJZBsRlqqjNAjEQuSBOJ5BQQZLhOxgKH70QHEFlVgYmVGrPouIqAgoiHISkithKuE8orFU\n4ekqoly9MILKzpeJrKopFqE00hY0Mo6+gn+uNA0oVTwFESS5f5dLXfEb/VSLfP5hC9fx1ksO/KC5\nnQqwhDdz+f6D/6yyGXF+CjL/oQ8kgB2GxtqBdMsdruK+CrmyjMHEN2hxy9Sc6fsVzkwiOxDxNjnR\noX5xEHkgDU9SkMESIWuI8obkQNQTW9Bam3687q3TB5LVC2Kky5kwZynlUqW/q4gyr8Iq183sbbAB\nr6bWHVZv9O+ri2DLSwaUUTwRMeSKyXIchy7DTs624LdV8q2lVN0LE6jAIz8LlzP7J+ER79fI8tVf\nRKNToHgX/Rr5EH7zvIV58XNxGQqLD7ABX7pCLtdKdd/XSIYsmSlkByIyRVByxECk9njS8ES9VbAw\nZDCzqCGK1nYhgpZY/Q3JUu8z3xv9CVYgqCBiGeBNmLOUYqnE3V9EmVcRJduBSS7zamqL0FvbzIiz\nr94NsMywuKNRPBEx5Hqw57AqN8ZrZAMgprI8ix+W3Z1wIWReQMuxZuU1Ju3KtAG+wp11+qj6M1yH\n55fh43X4C74nfD2/nJuHqRo3xgvCT/YW2Zj7KuSx2S0YqMVm9WSjhiELZhqyAxGuhiUWNhyRBcWz\nhscpaMHCkCNZ1BB5azsRQUus/l574r2t8m8a2HGzIQWR6/AmjJWSFkVF1LPtL6LMq4iSr8Mclx9j\nVwUpfoyJPpIRZ19dDBPYWOTgUEbx2Ix2tjduFet8eqGn2QlxpDGKHwpLz9/aoA8Gm+e2/G0e4Nwq\nfqP8zq04Q6TzyWLewz04C+F/BmxDzzcOf5k+smRuvOXO3+FzovoFJLn1lL9u+irk3BW4tmyPTevJ\nRg1Flsw0ZAcibD6Mb+1J2HBEzoneHAVDTkELFoYcyaLN0ImoJ9b4RftHv/DdHtQDCyLX4U0YKyUt\niiqlnm1/EWVeRZTc3INdLvNOUJCiQ8l8JCPOvvr0HT80oYzi0aniHrplYe/dXWxDbqxdrufyEraR\nftDtaYVeDr/KPUX1Z8jZSoOI+EwMTMKW6QA7ZGtndsyg5j7Y3oMykXA1zALPz0rJEKSvjgwXcBuZ\nbA3ZYhZBlojkpYQMGwtRZygpMCUL1hcZ+mSRgiiGZGgj5jpED9va9CJO+W6xTn66xdGnIMKElcKT\nMJJwkbpch7joS+1XRH31xE8d2spyHarWNKF9xeA0R9kObGb8f3gd3dPD81am0c9ZPjBuDETH3nSU\n8F7HpF9LryJK19Ev8EQiR1mk/t9sjGd8DCbHQpVLRTYmunlysg/uayLDYW5YkV4K2WImbZgTRxyv\n4Tc3FTYWok5TUaBaDLYqcp8sUgyVLzK0EXliF7rUWpzys79HMaggwgWvWApnwljCRepYRHOpniJG\nVq+FQlFbGV+EpsGfnaC+YpC6oygem7nwHrwWyRfriUWm0c9CV6jpWpTpvR5G2pBhUr4hDN6Owplw\nBZ6JRI5N7KKfJ7t0dCb+Oo9Jl4jZjMiiUJhXEzlTM2dxpJCjzDzII+18Gx+heNhYiFZwpSB4qyL3\nyaJCEpKNKBIbeX01tkLeZeYbwjGoIFgyq5Q0JzThVCJ4jlIST1cRzdULMvbVBRnWVxZWpmaoDnwe\nhw/cjaeCTIYyyHSYnF9WOiLhS0dy4OaQh19oEynXJGdyzON/z91a5xJeQLYtGbBjqUqu5RaUzn0X\n1ciHoSIz8J1NZFU/aS+RLWYe5Mrcl9BZTMZClEFtgeCtitwniyGIIrH0hZ9yGD2ri4OYBcFSuBNG\nEy6yIyKqYP4imqvXPUzZ0R2BfWXi4ChSvNY1mIZnX8EJ58Ytvmkv+jdw7AlZe4zAdyO+o9iwZ9gD\nuvrQBHw3kuA4YPtYyH2Y2d6QPqII4kCOk0UBo11FYsl9yT7iFUQrRZ+EiYh6NM0zSRFdkGF9pZNg\nciTFLdwaNFEkH2F4C7Y3WRElHqPssYMN8My2pz0P/5CaeMIpf/wBvhxZrNTjuQVYp4+cPqJYxqBZ\nZDiD/mMNZA9dslIk9xQZsK9kc2DyvtLxcvMLdXhofBl1V+LTlrV5bz83Jk/k2kG3p42e9sTnNF0M\nMfNCY3wWPvzEH6oxnIJM00dOH1EuZMAschzXP6QhQwQIZA9dslIk9/TSytbzreR9ZcAWG9u7mW6h\nicqz8bnJ2rwnNu3tNrzYhrfCygr5kUhwlI6RnYH3r9DNPAn8/S7pI6ePKNnjXeVSSJ5FjpOfkYBJ\nBLqHLlEpknv6eZLNgQNnhMGP4Z6mCdjexhFuUbI3WW3jLJZ6XGCXq9SWPEMfOBirAe63G8aRPnL6\niHLdA2aR40wOlkm1h07yChSSe/oDTO3r+SfjzYxBofUoHKyjF919J/PEd3yJ1h5pGbhie5qhDB+M\nLML2erh5DMv0kdNHlMsZMIsc52BVAiYS2B66JK7JPb3R+OZA73yMiQshu3UebiIe+EBi7xUTr02K\n7G0fMcFD357GNPHOuJnxrzBgRdwR00dOH1EwHzSLHOdUgZfsqvbQxfVP7umNpG0O9NqEThyAsXsB\n6Osj/Bppb7ISXyNhn45Y1Lbk6fpQ+SDAz4tDae30kdNHFFkaNIsMp/KSwEt2VXvo4von9/RG0jYH\nem1CJ2Zg4hiMktfaZPdddJOV2rRHfxErQce1LXlSGUO4DuCNcgz7cNP0kdNHFKsZNIsMJ28+Kgrw\n4KvaQxfswg2Te3ojaZsDvTaBEze92C61SztevBbt8dnD2mQlN+2JXR8MV9+eFhjJMMMPiEOLhiat\nQfrI6SOKtQ6aRYZj/a9qBXzgVe2hC3SQZsk9JURU0DYHRqcGGavdd5UGwcFXA5DrAD/YX3KJ0cZ1\nrWTA/l/VrhVma4iH+vVmEVmxHV/ltiQo3nBLxYawFjIw6PPIWljD8DnIjSpqr9gmFXVsVskb0prJ\nwK/WDJO1TETuvptHlmyLnex21Ny4lrmvV26V2npdeax12xu3jG1ZY71YaBvGxyMDm6vHI8qbJ8b/\nAdn5h7i6IM1uAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABbMAAAAyBAMAAACUgVv/AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAEM3dMiK7mat272ZU\niUTExn7MAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAQ40lEQVR4Ae1da4xkRRU+3TPdM9Ov6ayR7GrI\n9A4oaIgZMagQCK1/fP3Y/oEYAd3W8FxitiWKK1F3QDQ8YraJDxiQbOODhURhWF0V/bGNgAlIMiNE\n1tWQ7UQxEkNmFhaUh4yn3lW3qnrq3r69GTJzE+49deqc73x1zpnbt+/ULABJjnIvideGz1AzsHmo\n6OsF/NB6WeibaZ2V2puJ7RrlWp5do8TWN63963v5MVa/1Wv7eDUyNdqKKOINs1G8eO59rIeA7E9L\nHx5BU4Mi5xeDwvQ1+tTVF/ed7zM5KH0H9BDKR6Kcf9QRi6oy90VnRppRTZxxbuewWnsIyP60xFmy\ny3Zg5MzPXLCxdJlZONKL5SGNB6YvkaQwhPIR7BN2eVs7b92jb29KOvGFzGV7htTaQ0Duk5b4Kzc8\nUkB+3ABMMhivQqGTxLFfvyTCQ6chlI9RmfC29kK0E3P7m0npU7+9UcCB0HTn9JH9adHjJpEHRx5Z\nTBJX9ynMwPgxXREuD07fjpV++WgMP9UPRDmUs82oKtZ4SCtADukj+9MSa8kO48GRSy85YGOpskfX\ndWsXrQQe2GjtWA3kNh68tcG66bgj9dWOeD+t+7pBCvStAOnfmWgIL9WRZoRCpr3R2pGUJBl6Ex4O\ndjCFJ7ulhE81KdC3Fnq8W3tbL0KhDButHUlJkmEKvTHVThLY9Hm/OQwepUDfinW8W/uaKINHNlo7\nmpIk4xR6I1tLEtjwGWsaw/BBCvStYMe7te+JMMgsbrR2JCWJhin0xoT1NSg2k9tie3CHFOhboY9z\na4++FmFQuuGGPfcM9Ek4pBUgz/SRh1FBltAUkHOvRGoTe1hqwSdjO1GHFOhbgdMvX1+qrjtDoWmx\niqMY0gqQQvrIw6ggy1UayHfHSbvL9iMA33fpV9elQT8aJf3y0Qg+qvlOlADAZNPWxdAMaQXIIH1k\nX1piLNdjmgbyDg92qDp3zjO7ZkKNTbs06JuIwygfiTB204s3RyPRseMOXd7533nN9hOabIrFujlm\no133f1B3H9UHLnun7pcubQQZ/Mwc3k7EaFpiIYog6SOLxB5piBj61U9S+Anr7MrKyowY4DXcM5KY\nJEWMkoFI+fxkNMZcdKbYNjM1Uy1zbI1yTUslFddLyS+c75w64cdOtVSO16XoFUxmaSOuhqdohXIN\nRwSe2IM9FQUgd+iZm3FsLls3AOFnKuUouae7iBLYLfTvjn5kLLyQFFtOS21LZSq8OxHf0oCsaeoc\nbXVq4RS3mmozZwDU+szzqQiztBH74SlycbiGIYJK7DajOE/WYRzTElm2oqL8lM6Qknt6imigm4Pk\nZEwcHAWm2PJb6FoqU3GnOVSjBYCJRT58q1JHJGkS0b8ux7ZvaRlAhM00pGFUECZcnzaixOtDASAO\nV4kI9pq1xanEGh+pm5pY5X0qM5oHE5WfNcUUkYQpK+npWaqviApBSmJlEtK3Vi8ZC0pPsZwMEPbW\nVzH6qW/+Ksx0h08+5jOCgrs1K2prg+07VgN4G0cstb3QJrO0ERVeHwr4JSacq0IEe83aKlViJ2c1\n9UlE3gNgLlszUH6aUhdX9/Qs1VNEHVvIYmWKjNAIC371kpF2wlFPsZwMEHa7W096VmakGBHOwfFp\nXCdYRExw+HdbRTRlBWv7kt2c2S5z9CQbJyPM0kZUeH4KyCIGV4XYv7VVYvVXVeU3SEKO1CPLJkp+\nKD+hMa8Bnp6leopowrORqKYiIzSmtZ+MtBOOeorlZIDQp7Wfv+Rjt1XLLQTZcttn72xTsBO/Crm7\niFT59ss3Aog/GBYsqA0/VZ4+b+5aapGZ+9Zzh/Up7NyvPXgJ13BfiQz/2nl5G2hctHAmWzLTkG3E\nzKE2XFAlUWIgclI6Q0FBBUuG7GAoE6MQ9cQWapIObKfy7l5YQZQflVwJkwnXIoqlSndXERVXaQaH\n76izAaumBmn/GEsyrr7Cu94cfx/CG8Monoq4urSH1t5pt/jNbrmZn8fnjsXimSM1arP4OEwsU4k8\nAcF+KoJNH/Xl8bPhabgSpRPhF+3TuSW/TL0DbuAiX4FCBnxOg2KNTVvJJmrJTEO2EculDuxlKOGI\nzB7PCk9QUMGSIStEkS8nopbYwoykA0ewEAA762EFUX5UciVMJVxFFEuV7q4iaqsXdtl6vsVkXk0F\nKdYqTLXqOfsKTobLDCijHRTK6hI+vHmOXPdUKC6PdLFJq+WjpQYxy3WvgnyTSPQhEx6moru1L8rO\nwkE4Gy3+BEeqj3JLflmow6WGr4YM+JwGJV5VK9k4p5hpyBYiXIQPaTxIOCInBaDwBAUVLBmyQhTl\ndiIia+CJHelIOnAuLcCrEFYQ5UckV8K0hKuIYqnS3VVEbfXCbjuMVpnMW1tBirUKU42Ms69yy/Ah\nA0q0w6b3keNkmMSX9asdFIC1tnADzScDr0P5aKGHd225YSoD98JkmzqSJyDYRkXV2lrY5epkF1ua\n/E1xFd7J7TInEXqn1wndew1fDRnIc9roMpsWydaRFTOFbCNCtdAGvgsjHNHBUFBQwVZBdmfRxVAm\nRkPUEktaW5RmheSj9AqsWhDhoDK27EqYlnAVkS1V83QVUXGVyZra1yP08OCtrSC5RjWWIuPsq8yr\n32BIAspoBz4VdNld9ZrhN/p8h2QSf/Xe5lao21an8lQPL7S1n5yePmt62n5pu1SFHcD+XN7a53MO\n5I4RGOWrkDPkCxNt7fL09Ek/mp5uEUv90JhJZBsRlqqjNAjEQuSBOJ5BQQZLhOxgKH70QHEFlVgY\nmVGrPouIqAgoiHISkithKuE8orFU4ekqoly9MILKzpeJrKopFqE00hY0Mo6+gn+uNA0oVTwFESS5\nf5dLXfEb/VSLfP5hC9fx1ksO/KC5nQqwhDdz+f6D/6yyGXF+CjL/oQ8kgB2GxtqBdMsdruK+Crmy\njMHEN2hxy9Sc6fsVzkwiOxDxNjnRoX5xEHkgDU9SkMESIWuI8obkQNQTW9Bam3687q3TB5LVC2Kk\ny5kwZynlUqW/q4gyr8Iq183sbbABr6bWHVZv9O+ri2DLSwaUUTwRMeSKyXIchy7DTs624LdV8q2l\nVN0LE6jAIz8LlzP7J+ER79fI8tVfRKNToHgX/Rr5EH7zvIV58XNxGQqLD7ABX7pCLtdKdd/XSIYs\nmSlkByIyRVByxECk9njS8ES9VbAwZDCzqCGK1nYhgpZY/Q3JUu8z3xv9CVYgqCBiGeBNmLOUYqnE\n3V9EmVcRJduBSS7zamqL0FvbzIizr94NsMywuKNRPBEx5Hqw57AqN8ZrZAMgprI8ix+W3Z1wIWRe\nQMuxZuU1Ju3KtAG+wp11+qj6M1yH55fh43X4C74nfD2/nJuHqRo3xgvCT/YW2Zj7KuSx2S0YqMVm\n9WSjhiELZhqyAxGuhiUWNhyRBcWzhscpaMHCkCNZ1BB5azsRQUus/l574r2t8m8a2HGzIQWR6/Am\njJWSFkVF1LPtL6LMq4iSr8Mclx9jVwUpfoyJPpIRZ19dDBPYWOTgUEbx2Ix2tjduFet8eqGn2Qlx\npDGKHwpLz9/aoA8Gm+e2/G0e4NwqfqP8zq04Q6TzyWLewz04C+F/BmxDzzcOf5k+smRuvOXO3+Fz\novoFJLn1lL9u+irk3BW4tmyPTevJRg1Flsw0ZAcibD6Mb+1J2HBEzoneHAVDTkELFoYcyaLN0Imo\nJ9b4RftHv/DdHtQDCyLX4U0YKyUtiiqlnm1/EWVeRZTc3INdLvNOUJCiQ8l8JCPOvvr0HT80oYzi\n0aniHrplYe/dXWxDbqxdrufyEraRftDtaYVeDr/KPUX1Z8jZSoOI+EwMTMKW6QA7ZGtndsyg5j7Y\n3oMykXA1zALPz0rJEKSvjgwXcBuZbA3ZYhZBlojkpYQMGwtRZygpMCUL1hcZ+mSRgiiGZGgj5jpE\nD9va9CJO+W6xTn66xdGnIMKElcKTMJJwkbpch7joS+1XRH31xE8d2spyHarWNKF9xeA0R9kObGb8\nf3gd3dPD81am0c9ZPjBuDETH3nSU8F7HpF9LryJK19Ev8EQiR1mk/t9sjGd8DCbHQpVLRTYmunly\nsg/uayLDYW5YkV4K2WImbZgTRxyv4Tc3FTYWok5TUaBaDLYqcp8sUgyVLzK0EXliF7rUWpzys79H\nMaggwgWvWApnwljCRepYRHOpniJGVq+FQlFbGV+EpsGfnaC+YpC6oygem7nwHrwWyRfriUWm0c9C\nV6jpWpTpvR5G2pBhUr4hDN6OwplwBZ6JRI5N7KKfJ7t0dCb+Oo9Jl4jZjMiiUJhXEzlTM2dxpJCj\nzDzII+18Gx+heNhYiFZwpSB4qyL3yaJCEpKNKBIbeX01tkLeZeYbwjGoIFgyq5Q0JzThVCJ4jlIS\nT1cRzdULMvbVBRnWVxZWpmaoDnwehw/cjaeCTIYyyHSYnF9WOiLhS0dy4OaQh19oEynXJGdyzON/\nz91a5xJeQLYtGbBjqUqu5RaUzn0X1ciHoSIz8J1NZFU/aS+RLWYe5Mrcl9BZTMZClEFtgeCtitwn\niyGIIrH0hZ9yGD2ri4OYBcFSuBNGEy6yIyKqYP4imqvXPUzZ0R2BfWXi4ChSvNY1mIZnX8EJ58Yt\nvmkv+jdw7AlZe4zAdyO+o9iwZ9gDuvrQBHw3kuA4YPtYyH2Y2d6QPqII4kCOk0UBo11FYsl9yT7i\nFUQrRZ+EiYh6NM0zSRFdkGF9pZNgciTFLdwaNFEkH2F4C7Y3WRElHqPssYMN8My2pz0P/5CaeMIp\nf/wBvhxZrNTjuQVYp4+cPqJYxqBZZDiD/mMNZA9dslIk9xQZsK9kc2DyvtLxcvMLdXhofBl1V+LT\nlrV5bz83Jk/k2kG3p42e9sTnNF0MMfNCY3wWPvzEH6oxnIJM00dOH1EuZMAschzXP6QhQwQIZA9d\nslIk9/TSytbzreR9ZcAWG9u7mW6hicqz8bnJ2rwnNu3tNrzYhrfCygr5kUhwlI6RnYH3r9DNPAn8\n/S7pI6ePKNnjXeVSSJ5FjpOfkYBJBLqHLlEpknv6eZLNgQNnhMGP4Z6mCdjexhFuUbI3WW3jLJZ6\nXGCXq9SWPEMfOBirAe63G8aRPnL6iHLdA2aR40wOlkm1h07yChSSe/oDTO3r+SfjzYxBofUoHKyj\nF919J/PEd3yJ1h5pGbhie5qhDB+MLML2erh5DMv0kdNHlMsZMIsc52BVAiYS2B66JK7JPb3R+OZA\n73yMiQshu3UebiIe+EBi7xUTr02K7G0fMcFD357GNPHOuJnxrzBgRdwR00dOH1EwHzSLHOdUgZfs\nqvbQxfVP7umNpG0O9NqEThyAsXsB6Osj/Bppb7ISXyNhn45Y1Lbk6fpQ+SDAz4tDae30kdNHFFka\nNIsMp/KSwEt2VXvo4von9/RG0jYHem1CJ2Zg4hiMktfaZPdddJOV2rRHfxErQce1LXlSGUO4DuCN\ncgz7cNP0kdNHFKsZNIsMJ28+Kgrw4KvaQxfswg2Te3ojaZsDvTaBEze92C61SztevBbt8dnD2mQl\nN+2JXR8MV9+eFhjJMMMPiEOLhiatQfrI6SOKtQ6aRYZj/a9qBXzgVe2hC3SQZsk9JURU0DYHRqcG\nGavdd5UGwcFXA5DrAD/YX3KJ0cZ1rWTA/l/VrhVma4iH+vVmEVmxHV/ltiQo3nBLxYawFjIw6PPI\nWljD8DnIjSpqr9gmFXVsVskb0prJwK/WDJO1TETuvptHlmyLnex21Ny4lrmvV26V2npdeax12xu3\njG1ZY71YaBvGxyMDm6vHI8qbJ8b/Adn5h7i6IM1uAAAAAElFTkSuQmCC\n",
       "text/latex": [
        "$$- \\frac{1}{M{\\left (x,y \\right )}} \\left(- \\frac{4}{h^{2}} p{\\left (x,y,t \\right )} + \\frac{1}{h^{2}} p{\\left (x,- h + y,t \\right )} + \\frac{1}{h^{2}} p{\\left (x,h + y,t \\right )} + \\frac{1}{h^{2}} p{\\left (- h + x,y,t \\right )} + \\frac{1}{h^{2}} p{\\left (h + x,y,t \\right )}\\right) - Q{\\left (x,y,t \\right )} - \\frac{2}{s^{2}} p{\\left (x,y,t \\right )} + \\frac{1}{s^{2}} p{\\left (x,y,- s + t \\right )} + \\frac{1}{s^{2}} p{\\left (x,y,s + t \\right )}$$"
       ],
@@ -166,50 +168,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABWoAAAAvBAMAAACIze45AAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAzRAiu5mrdu/dZlRE\niTIDEAIKAAAO+UlEQVR4Ae1afYxcVRU/Ox/7MR/bbhW1wcA0EooYsvNHE7GgO8pnMNoFAUn8YEHD\nVyI7IZZVDHZFEI0oBYyFEOxAQ0H/gJEPFUnsJhgIJriLslZNSEejSPynS62htdD1nHPvuffOu/e9\nnemGMqXvJvPeveeej9/9nTNv3ntzAcJtVVicSlMGepeBdXt6F1uKLGUgyMAJF6dVGyQmFfYyAwNp\n1fZyelJsQQbSqg3Skgp7moG0ans6PSm4IANp1QZpSYU9zUBatT2dnhRckIHOqrZ84QXt1vNnVdoF\n7/TRcha8HNt4Xr2cxKt2MnNEgJSFdFa1f4TLxIDP5Wr/yjbBO32wnAUvxzaB12hOElQ7mDoiQJp1\nJFft8IxSvAt2V7mnBUPV4f8YF0dCp75MkMtZ8HJsE2CbnCTodD7ViyDjk5Zctf/Qy74Nxma4qwWD\nM9k3OmekBzSfXSaG5Sx4ObYJsE1OEnQ6n+pFkPFJS67aVWbZOyrcNYLikfXvRLlhVnKIneUseDm2\nCXB1ThI0upnqPZCxSctftf+a+KXl7TV6C2tZwZCdAvh3rItHYmdwIt6s0ArbDTfC8iSp8nWnp+L7\niovKpnbB3cPuxNbDZwVxJKqcoJ6/FGvs9eJW2YMg/aR5qwkIxiqQOXczTZTHeRoFus3TOTv/MtV8\ntkaDYOtvRcTZi84UUYIZXBsx08N1YXGylH1tVDrbF5vYGdj3SYCAr0DUf4pvXjANDgH2EraaY4nk\nnT0SlYbOCQ7al3LC9zwPbYLAKmk+CHIpX9ZxJyCXWqj1pgpAJ80Rd9KlhfRxvT6o1M3KCix9sQX0\nLqGvomajx8xdADjd1k6EstwR91XaZuzgg1XosyO3Z25QXGFiX3yNaa3JOey8QhACvgJRf6Tt1IJp\n0FfBQ6hJKG9uSVvFsWfHghCJSlPnBAeRpRwT9sTSbkEm+bJhOgWZtFDrDQSkJM2Z6qD7fdRZ0cRD\naa7UIn0ScHsBfg+wpgaQuQXgRi2MnooLztwH1OzlAN/VenFmsAOvhlRcXgtLPTUS6HDG11CD1bIP\nT+B5OwIL+fJlAzezGQAvmPsdwZbwbLGkLXPMqm12LHFJzFRZpA6SE38pB0SrTV8JXW7bgsWATPIl\nYQBckIZ6mo6AtAsNQLPuBKROmp3opDe8B7VmK3j429NP0IkFeIbhY5/+BMBq6k4CfJvOgZZfCXCS\nyH+pOvjrNdlS3TgzOB+/DNNKp/046GatfSo60uGMr3yNNQrrEFPhJByEfPlR179bOVYL5n5HsCU8\nWSxtyxyzc9eOBeCSWKwrGR91TrAfWUqJ0satTV+JXG7dYDEgE33pKHhyQYLrNgLSLjQAzboTkDpp\ndqKTXmEatf5CmrcvLtKJBdQZXFxc0D/1u1qlzSQKtKE5/D1t6gm9luMrUrWxZnAfmhwb8AfPh4Rh\nmVAnvgamWS+fx/PpY5j9oC8v6pyuWl4we+gMtoQnk6VtmWP27tqxAFwS21Ktc4JakaWUTT7a9JU7\n4YNGbrAYkIm+lEc6uiDb3EZA2oUGoFl3AlInzU500qNvEBzz669WRZkFsPOGFgvGaBounaGngszU\nl57bydLMfB1OrVD32Q1n1+UxzqVoa+WFM/51fYXMYO31p99YJ2U45bOQvYk6pS/vvdJ5NiARCl/6\n2NTl/MAQiqR06CjYNHXWl75o5AcWAOqPtlQAG12jNvft2mOhSlUrTruAbQoiyVYHcTnWdjEkmlSX\npx5h4xAt0Pe5h85QrkU/htsEkALN9xXiP5xpH6RTTALNpiAA0l7pBU8H51wNy/G1av+E6JIA+lo5\nqjeAXQ06bmjl8HwK/LR+Bw2hXJyGTdyje0oorFR9+w0svQlzVzfLNTLLzBW2DCmNuV8BVRQ2ukmC\n+7lrDuX+e+ElOA/HwUiiZ7BJOONr+CDrrC8ehGIF72rIlxNdo45EhbWAVWucdgFbCiLRVlA7HGu7\nGBIl1XAcnMXGIVpg9F1whXIt+jHcxoMUZAFfQf6DmfZBOgvV0JwUBEDqpBk0HXX6JrCEDgLXKhuQ\nAMZguMKjrVU67YOhJsAfYFflcZaehhfkM7lH95RQ3Kz6Ukb4a1LLNt8DhQUyK1fKe4rsJts8XwLx\nFf0pbaZPp2HoR+FeHAUjibLBJuGML/1f3rbsAfgQ0CMW+rLRQaOORIU5qlpx2g1sKYgkWwHtcqzt\nYkiUKswuwN/ZOkQL7GhJArR+HLfxIA00z1eY/1CmAyCdYtLQbApCIDFpi101wj00zvfZg3VZBAlg\n9JYZNeZb3eLrMIjjCqWXWwXVX1dduj0ZXlB9KSOACyEDB6C8h8wy0FdT8xm4FVaoQHSTBLtJnFl9\nD7Y7Wugfnz53VW5DWSiS0TPYJJzxhdVKbRyx1bOED33Z6KBRc9Q1FPSe41Cn2KJlidOOYaOlFESS\nLUgg/GoJx9ouhkSp2sy+z2MMbCFa6GJxq5rW+kFuUSMB5GqiAIn3fAX55yeRaKYDIJ2FGmhJBaCT\nphbT6ZEurZj2sZYY8LW2tGGvGt9Np6HNXLUglUovHfSFPUNvRdVaXhwZuXtkhN/9DUzgXeoeyE1T\n1eKLNVWpLNvdIgmMzuCB64dGus1W4FyqNGxUc9xMJBGAxmbDGV/6WjsOtxSrBbpbYF8mukYdiXoK\nUNWaBXcK24ZPthXYwrFjZ5ZmSSyPjKz+1sjIOFn9drGmjEO03AdZWqCjj8A9bp1goQUq91iOUV8h\n/i1IcNz6IGWhDrTEAjikzS5UpJj2P+P3SzUSZJuZTVUeTtJxU4vvEAArNcNS/HoOTHOvtICGpc1K\nar7YT0K2Wt4Mo+N0h4DV2dLe8Xv4NaU6S54iz8X4KiPzX/pVx++BH0nZudgknPGl9qhlGzByMvRP\nowH7MtE16kjUX1xxxb4r7YK7gK0vY8m2AtvhWC5/YRLlWnsarNVb7gK0YAmVp1UuRD+G2ySQClvA\nV4j/YKYDIJ2FCrTEArAbC7vY/dtfA7yZhB8UKppfEvRNwwo1nJ356DeHfwiQawA8hk9S1ynx2ZCb\n4F55Jf7CRp/GhsdhoIp/kTxcIbNiZRMMVFgbjc7mDrwIv/GexuAYKNzET2OhSMrOxSZVa3ypx9FC\nFS6pw2ANDfBpzImOsQn1/eLJnG92FtwFbF0QlqyQrQRxOJaqDZMoqX4fwIIyDtBSWIDBuQd4WvRj\nuI0HKcgCvkL8BzMdAOksVENzUhAAqZKGYLrZ/UvXzMsA3ijLIkiQa8GUGg/cOV7ejpfd8gSUDuQW\n8Do2uhJnLoRZ1ctPrMX74nFtrCn6yMvzV8OKGlY7msFscwOsx/cUqJOvlf6nehdn6gAXaTM57YVX\nW/An/LkORRIli02q1vgqTJPSEP847Eb/5MuJrlB7UQH2OgvuArZerQUUsiVE1ByOtV0MiVKFn4YB\nWgK2AC34H/uKmTmeFf0YbuNBsjUefF9B/oOZ9kG6C9XQnBQEQKqkIQ5/9+9wQzDKWXYFUanjJWle\nUYCzJMhOPdTUiq986usz0KKbgMyV1934M3RO/8qcuPPSKvey5yC1fTNaWVN0/OLifph9YWOV7x1O\nnFr71wbA1go+Gn1lI/7qUW/dFJq8Hz9OK72x8zN82xCMJIoONh3O+MrXUKn/9i1Yzk/c/uMK+3Ki\nK9TRqAAvLV5jnXYBW4dPthXYDsfaLoZEqcIP3/ANZRuiBX/Dyl9Q06Ifw208SEHm+wryH8y0D9It\nJg3NSUEAJCWN9++o3b+FSX6k3nQzFuA6gWjP1+quevqxcv04ZAW5JlX4XUbwDPfoPYjqAZwqc5IP\nGqu/SKxZqUpSvPsC1cPvxjRJbMNbSmxDrMdSP5JVpp4Tjn311dvnHV86JqKORo2YdAHbCa+chG0j\nAVzYIRKlCo1ZDC0yb/WD3C4JUvzQ2fpiqc9/MNOk64EkYbu7mALgpPEzPPDu3/430XJ4cgaPq/AT\naX16rL+ydjYqyE38HCcfNAoN+lHhJ0rscdupz/A76eBZAbFmBZRdxu8OqEetHCkyvC3EVuAj9aDh\nRWKxOTjh2NdoxUypjvVFMRXqaNSISRewnfDKScg24p6G2i6GxFIjYhKixVER/RhulwTpuALxpWUN\n4YwywS2YaZrxQJKw3R2lIACSk8bXVxiiglj/HTwUJvHg73Oysldxvq1FBflFeseSq2qlTAOvh/Uc\nBqAetcxKdW47ZhQQYwYn4/QWOAeP1KO2Rp3McbTJ3TNE4EeSGf/MvrZ7cuOLYirU0ajtNocA2zgI\n2ppZr9MBiWwTosVzthS3xsADaWa8js9/MNNsFwXpOVNpDxQAJU0/kc2T1baP4+EB+o9oUEqOxLpl\nplWnX9WKiPHrFREM302CbE1r0FemNPVFPFKPmq1MNebjU6/V6WzM+Ov63MYWyhr4oWZKSg2LW9/L\nHXM340dSiqEj+/qJN2N8NXBKoY5EjZh0D9s6CNra6WivAxLJJEhL1BeOE7m1+h5IOxXt+fwHM01m\nHsioLxw38BMASUlT9xfql3H8EqyaZ15H6fP48dqxSuJ9fzyB0lvvORDBNumEzvFm+IYq2LKNoDhR\nyL4Kc56O7ysuasS0e9jWQbyt1fF6iSSStr8Uz4cVLL3KXgHJSVP7d9Tu3/FNeB/A/xHRpdfbeMPX\nY5x40i5W9TxBVKFHx+bC2qP4UlgBBjhpvBdI7f7NNna04LH+BVQ9D28+vZ1X92sfxWbEmSeIzPfq\n8IJeBZbiimeAk4aFeqbeolyojjUzzcEaWtyLtw7ezqvo3qd4z+lMysBbygC+AbxVB8jjpoUBoC39\n7XufZHfQ7rcUSOo8ZaBjBvT+HdLPw+D44/BoC7vte5/wPQPuKPF2XKFe2lIG3gYGnP07+N9/36oG\nXEUo8A7B33kVfLFAimlLGTisDBTsXiDYBnm8WaDXtZG9Tzm180qexg4rwDRYyoDHgLN/BzbDwEEY\npte1kb1PvPHG33HlOUsFKQOHhYFcw+wFump/vVgvnrv/cgyMNwPexht/79NhQZgGSRnokIGhqija\njTfZaZGl55SBXmSgfe+T2nizxN6nXlxGiunoYsBsGTkZ16023qw5uhhIV3vkMWD+om8gdrXxxhTy\nkbeaFPHRwYC/YWjpXUFHBzPpKt92Bv4PAGGIsABggiEAAAAASUVORK5CYII=\n",
-      "text/latex": [
-       "$$\\frac{1}{h^{2} M{\\left (x,y \\right )}} \\left(h^{2} \\left(s^{2} Q{\\left (x,y,t \\right )} + 2 p{\\left (x,y,t \\right )} - p{\\left (x,y,- s + t \\right )}\\right) M{\\left (x,y \\right )} - 4 s^{2} p{\\left (x,y,t \\right )} + s^{2} p{\\left (x,- h + y,t \\right )} + s^{2} p{\\left (x,h + y,t \\right )} + s^{2} p{\\left (- h + x,y,t \\right )} + s^{2} p{\\left (h + x,y,t \\right )}\\right)$$"
-      ],
-      "text/plain": [
-       " 2 ⎛ 2                                            ⎞              2            \n",
-       "h ⋅⎝s ⋅Q(x, y, t) + 2⋅p(x, y, t) - p(x, y, -s + t)⎠⋅M(x, y) - 4⋅s ⋅p(x, y, t) \n",
-       "──────────────────────────────────────────────────────────────────────────────\n",
-       "                                                                            2 \n",
-       "                                                                           h ⋅\n",
-       "\n",
-       "   2                    2                   2                    2            \n",
-       "+ s ⋅p(x, -h + y, t) + s ⋅p(x, h + y, t) + s ⋅p(-h + x, y, t) + s ⋅p(h + x, y,\n",
-       "──────────────────────────────────────────────────────────────────────────────\n",
-       "                                                                              \n",
-       "M(x, y)                                                                       \n",
-       "\n",
-       "   \n",
-       " t)\n",
-       "───\n",
-       "   \n",
-       "   "
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "stencil = solve(wave_equation,p(x,y,t+s))[0]\n",
-    "stencil"
+    "stencil\n",
+    "stencil = stencil.subs({p(x,y,t-s):tb, p(x-h,y,t):xb, p(x,y,t):c, p(x+h,y,t):xf, p(x,y-h,t): yb, p(x,y+h,t): yf, m:m_var, q:q_var})\n",
+    "compiled_stencil = binary_function('compiled_stencil', stencil.expand(), backend='Cython', args=[tb, xb, c, xf, yb, yf, q_var, m_var, s, h])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },
@@ -259,7 +232,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -274,9 +247,10 @@
     "    for a in range(1,nx-1):\n",
     "        for b in range(1,ny-1):\n",
     "            src = source(xmin+a*hstep,ymin+b*hstep,tstep*ti)\n",
-    "            subs={p(x,y,t-s):u[ti-1,a,b],p(x-h,y,t):u[ti,a-1,b], p(x,y,t):u[ti,a,b], p(x+h,y,t):u[ti,a+1,b],\n",
-    "                  p(x,y-h,t):u[ti,a,b-1], p(x,y+h,t):u[ti,a,b+1], q:src , m:sos**-2, s:tstep, h:hstep}\n",
-    "            u[ti+1,a,b]=stencil.evalf(subs=subs)\n",
+    "            view = u[ti-1:ti+2, a-1:a+2, b-1:b+2]\n",
+    "            subs={tb:view[0,1,1],xb:view[1,0,1], c:view[1,1,1], xf:view[1,2,1],\n",
+    "                  yb:view[1,1,0], yf:view[1,1,2], q_var:src , m_var:sos**-2, s:tstep, h:hstep}\n",
+    "            u[ti+1,a,b]=compiled_stencil(tb, xb, c, xf, yb, yf, q_var, m_var, s, h).evalf(subs=subs)\n",
     "            if np.absolute(b-floor(ny/2))<hstep/2 :\n",
     "                rec[ti+1,a]=u[ti+1,a,floor(ny/2)] "
    ]
@@ -295,13 +269,13 @@
     "for i in range(nt-1):\n",
     "    r = plt.imshow(u[i,:,:])   # this is how you'd plot a single line...\n",
     "    plts.append( [r] )  \n",
-    "ani = animation.ArtistAnimation(fig, plts, interval=50,  repeat = False)   # run the animation\n",
+    "ani = animation.ArtistAnimation(fig, plts, interval=50,  repeat = True)   # run the animation\n",
     "plt.show()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -323,6 +297,15 @@
    "source": [
     "#COmpare with analytical solution, have an expression for Helmholtz, trickier for time domain"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -359,56 +342,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAC3EAAAAyBAMAAAC6va5lAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAiUSZq1TvELvdZiIy\nds1Wk1T5AAAbKklEQVR4Ae1da4xkx1U+Pa+e6Z5XZAQxyPFYyg8MRDsQk1iC2IO0kITg3ZGQTQxB\nO9iGGEFwI5koGNk7ko2x7EReKwkPGccjxTIPJ95RkCMTQDsCFBASbFs2CQpabQs7QERYj00cOyTO\ncOpxTlXdqrq37qPXvfheaftW1a3zne98dc6d7r4ztQB4dNbwpfzRWStv01qMWYFbx4zfwrcKtAq8\npgpYJX5RNSIVzao5a63SFJgapc1rZ7UKtApckAqYEu9sVAqgolklX61RsgKPJ89sJ7YKtApcgApw\niV83yGG/HL3omS2u5+AUX4p7KrYtmPEfBdfLX24ekTjURZ5fJaQmzn925YdrwdSNJuJ8jLliPI6J\nu3HQtloFqihAJd69Ice6f3/szu2bLWznABVeinsqNC2a8OTLRTPKXm8ekRjURu7+IkE1cO5uwKVr\nNXBqRxP2PcZcMQ7HxN04aFutApUUoBKfz3mr3L3zaOzO7Zt9YbsSD2WU46kGqjT90BVN37mbR6QY\nG0C+jrAaOM8MYG6rOk4D0YScjzFXjLsxcTcO2larQEUFdIkfi92bJezZ2FXPrP/4dkUiyizqqRaq\nMF5q+s49BkQKsj7XhVXCqn+eOwEz36oBUz+asPPx5YrxNy7uxkPbahWopIAu8Y/mGkdrxDPrLG/n\nIhVdjHoqMiy83nwNNo9IQdRHnv0mYdU/L7/c3rnrq9gitAo0qoAq8V5+ocfup77ZY+2du4HlqX/n\nBu9nai1aC3U+sDQQTZB8LCuDkysOjot7RTqtWasAKyBLvOC5YqxGPLPusL1zs7LVGw3cL07GvuCq\nxOpQnS9fGogmSDqWlcHJFQfHxb0indasVYAVkCV+eo37oUasRjyzDrR37pCAJccauF8cH5b0mTv9\n93OvFlxsIJqgh1hWBidXHBwX94p0WrNWAVZAlvjbuBtsxGrEM3tfe+cOClhysIH7xfKopM+86dPb\neVeLrjUQTdBFLCuDkysOJnK/6E73I062X9H75Jt1rnx7dZLjUakWJT+YySUpS/wmn7E9EquRrFl3\ntb1z27pVbSfeL/Lgl/KfXOSZ+tee8YdKjDQQTdBbLCuDkysOpnHv7M6MbAfZvn3t/1f7e+BI5YDG\npFIdSn4sE0xSlPji//qU7ZFIjXhms4cPH72p1sf0iCebTMV2Wg2WAW8ekbw3gNx/lcDqn2fX4S9q\noDQQTdD7+HLFuMvnvrimZi7sLuoflH8tB0zfIE1mq1axYkgPwundqpGNSaU6lPxQJpGkXjRR4kVv\n0CI1EjKb2/ajLzES8VQCITY1vwZjVnnjzSOStyaQbyaw+ue/AfjXGihNRBNyP75cMd7yuf+9nji3\n1n9RNhe35Yn7+vrknt5ck9oNcGqtKsSYVKpDyQ9lEknSomGJz2/5lO2RSI2EzFa2bcPS7Yin0ji+\nQX4N+vOLR5pHJJ9NIN9NYLXP/QfecMWJGihNRBNyP75cMd7yuZtNTWbVr03yViq6b4AmtNXZqUvs\n2KA6wphUqkPJD2bySNKiYYkXvFG+4paPBRc4YNa5/2v21EW744ryKberellP/xCaVDQWRJ7+iW/8\npG1YCrl5RKLS26OWdc5yzVHRstJNQrw051NsPPhQpMsHBwf2nTtuTb4dVploSgWTicnBzeRKGdwg\nTwdcdzLcM1OmhzywoJrvoAHd1924YiG9CQPiZrEAyovwe+yNGj5GzJu0eIjsKtA1KsVDZXi/EROP\nKfmh+CA8EotyAknqRcMSP77O/Ms0is2ejMPN7MWv0ZX+NrXs84d+2e757fLI3bvtO1N9xCKGloef\nstqxJqpYHvHkWhZu6egrh+95D46GZZXTE7TLsYaEaHJSIkvY9JvGTcAzzqOtUwNemIvkpL56541t\n0a+kd/+t9+xJrNxligldSlwpwtPK2SMHm4Lx138bIIDhy8Vbgnb41lEhL5Rq6DhsW5T0kWQ1lJxQ\nioo8pmmIZCGWXkI8pZAsAWcvGpb4oaHxVKJVbGY+Trqw3QcBRu5QqMcfPt2Lz7pdp1cNeZnzzwGT\nnSqIeQwtD7+5C8tWN9YUKpZGPO2v6coI4OQmQERWSIs0Zg1p0cRSIhY8NI6bxjPOh6/ImpYL01P5\nw/cM1a+i963QUV+Zx5cpR5B0cUmEUzqao6vY+FvhOoDhJyn/Dd4nWY3yeaFVQ4SIbV7Sx5PVUHJD\nySvyuKZhkrlYLElORbkkE+Eyi4YlfgzLucJRaLYk0iF0zO4DPKUvdHdDM+QYTclMeIn7v8UtalRD\nXmEBmkHMY0hM8XwM3+aQRL5jmiinlEYMfCA6jb6mt4zy5IDOtnY05p8ji5IYDcfrA2dGOC+SVCrG\nDeJlfJbryq105cJcBj8gTOcojVS/jN7E7p0Av6RZJAntMK4gwsKOROg/uoHnR/athJTj6sXHpS1B\np1an9vTEJLpOlmvV0D5im5f0drKSeJKJoZShvUKrA858RT+aZGGSuVhaEDylkjRwjkAGyCWpFw1L\n/Oxedk5Sv9BsbjeCMz0C+KC+NjuMTAL4leCVKf5MCj/vTaiGfGhAQI0g5jIkT3i+CqC7pfu+Y5oo\nVCyPuLJB9nw+u4ZA+AugYVnxrj4yq8JGXiNmnRZNNCU8P5wXSSoV4wbxPK8lBhZFHsqFWfzytb8j\nDE/rNNL9MnoTO/wm8OiewIovkyO0mqpfK4gwvS1te0+OAHofxE4Ig5NUzsUX3hL0n659L5VO6bwg\n1RAvbJub9HaykniSnqGUCcUUuTNfxRRLsgjJXCyFKF5TSRq4+G0A4YikXjQs8avx3lDhKDS7PAa6\nsIqfkDbV1YCM2mzqRNC+Y4b9OKshX8yOGkHMZciuAB7A9pd133dME4WK5RFXtsmez/djq/8CRGQF\nsLVjo2wjap0WTTQlsn6A8yJJpWLcIJ7ntcRAbwsny4WZOzjYF4aPihc8dL+M3sTu+QHdudOEVg71\nawURlrak7fQ0nj9zaggQxKAklXPxhbcEveXgQI+l0bWznFTDH3+mosmDOOcmvZ2sJJ40NpQyoZgi\nd+Yrj7Eki5DMxVKI4jWVpIGzBTI4ukUk9aJhiRfegj0MOZBjNvXGvzzzTvmc5vZnPvMUJgQev/4O\n6L9ftt58/11DoC8FAzICXHbfPz4zEDO6Z97zlkukEb8s//Cn79MdHWf3oiF8diDGSiCDYQbP/uy/\n7CrIWoiaFQQYchiG69S7XrlGPcsSdqElMyr6iBZ9FtZGnBsRGz6/gq2pr0nhjayGj6MdG1kNXpQi\n38FoTDBGeGZuvHTOfEp1dF7YMVXBzcczfsu3xBsqe6nleyKAS760p7HK6G1VwcODEkJrV0bc0Moa\nUp6o+n3t9NI+wPAkMhdf3nsLxE/ptDu5JSgry3RDviPrRyoFbLUPR9vEsiRKRg4TilXkJDanXypJ\npmZuGIQVit2pKJoIPkmLGt0GDO8ASb1oWOJH5V2PaaU2csw6Mx+HN8K9eOdd7T20MJKIq9eByA9x\n4LdK0BuJFn4XNFRn53X13Zud7fkdvN3Dnww/4VyC4/8Fh/WIjrMzuwVn1VA6ssWs++3dmQ1lXwdR\nk4IAQxOGxVV8CwaPaytaMgbBBqsYQLToG2EtxLkTNpJoL76KL0svgCurxcfWLmss+rwoRb6Dd1gO\nJmjN/r4Kd6o25YUVUxXcfDx2W6Exv41GVjIC3IMDy3vz6wqslN4ULf5sfaGM0MqVlSnBTGNS5IZF\nXVT/Z8bnZr8Fs4OjiBasWUpS7U1tCcrKcl4EfbMrYUxZzoQCttqJo21iWRKlUK5ZRU4qBAsnjyRR\nC2AFY7cripyCRxIsOB1osEZYSb1ocydArFiFI8fsieUNOAkfx5vPoPPy7K4A729eBTLZsY1f2MCs\nvrVwRGKSPvqbz0Fvf2ET4Lvg0sHP0bA6H9uTJSI6Os4n8O2PqBo80pENM8C0JWZ1EBUDfPUZmjAs\nrvJN2/XaSjtmDNFgFQOIhr4lrIW4sOVAYWdJFOnMi+DKavGxtcsaY98sSpFvXhgbhYMJWtPM/j78\nnWpTXlgxVcAtwCO3Vc6Y4s5SAzyHA6dgcaDQSulN0eIn7O0yQitXVqYEM41JkRsWVf/x52P9l+A3\n4GZEC9YsJan2JrcEZWUN3aBvdiWMKcuJUMhWO3G0TStLphTINbvItQrhwskjSdSsGwYpGozdriia\n6JO0qelAgzXCSupFwxJXt+A7/kAcXwXAv7woOvZFDHEzGODT0ksHN+B7bt6DqgsfgJWhil18YbMo\nMcx77hXjc78LL0Hn5bk1gAH8pzKB7lcEvU/siZvzB/SYjnMwN4RX1VA6smEmHiQggjzSEG2JDNc8\nhhyGxVV8CwanlV/OaaPCgVExELOhbwlrIao7N1NCL/NC8JUtcGW1+LB2tpXhYwUaWlTLt0l+Y22C\nCTKn5Ot+/Ye0IJTp9XAL8LQvIYyhmtASUi6s44uVjCD/O4vjN67hsDjS9cbJFC3AlVgzlP1BqYwg\nJBqWCdWbVTDWyjIpcsMYeMcWxzrWz1DudROsWZmkxpvcEpSVNXRNsVq+2ZXwo8sLiFDIlrPP0jat\nLJkSy2EEtItcqxAunDySJIF1wyBFg7FzRWHoNNEnaVPTgRreIZJ60bDErx4IVUsfeWaHBnA3YBZg\nSQw1MH47c3pPtrvi90blnbtz7txXfu3cOVEDzoFz57fELQbolmwuPwB9+RHvTefO/e65c8+KC4cG\n+gNEKWRmhsl1ag9haiMKLngEGJowmCscX8O5sigsx8KeD1YxhMj0jbAGERZOMIpuyGeWJ3fknduS\nlfkY7bKWum8tSq7vSDQcTCgl2OX3Hmxj28oLE1Ml3Bw89lmtId9z08JIiOfwdep+8fW2ONL1tqKF\npQ3EMNmfK7R0o16MuKFMU6QsNyyqfvu2DjfO7vZEWQVrlt5eKF96S1ClLA5ZdF9VM6yKDGc5qxSy\nJQzS1lr3QLJaUQFTMnKwgAu6yK356FzfkVgP+x4QIqm4BbDyK8pyGiBJcFagoRphkvSe+wRcukti\nlTrnmV0M3f8Rn7zw1rQHAwmLP6i+oPCn9nGIHijTzyJ1Sb/iY+Xj6+JjPeAtuetcwhtMZ0sP0Y/w\nq0A/bi2DbJihJN+pSdZDVERDDE0YzBUOicgu18GRYydWUjGEaOgbYS1E/BIsc5we4kcg/ECckZX5\nONplbGXXLEqBb/O2xYahYIIpQROfgNu/qdqUF1ZMFXAL8MhtlbO4c9sLI78t6W92z+4qtFJ6U7Tw\n09DfLSE0ETfiBjLNkCI3LKra5LC/A+dug5ktRAvWLCWp8qa2BDXKGroB38EsN4RCtjomW1uqjnCy\nUlSGkpGDbz9WkdP8YOFwkoVIamoBLOtGVZqkBUeB5laY3pkSS/zsnmZU7hQ2U1uRPwu994unHbOD\ns7A0kLjzG3CXctAZze7FnlCqjdGX1+HRgXiU9jP4UPOLDq3ePsyt/pEaojjvAgQXRwlki9lJgF/o\nKZKlEEHGylwlA3wJMLTCYK7wJnhf9Amlq2IA0aJvhLUQ/d8tEcs1P8J/O46szMfRDsOwDzfQIt+c\n/BrCDSZoTc7+HWBftam8rJgq4BbgkVs+l9iXf2bbXWqAd+EDyi1Y0WCl9KZoF9dhaZczKiiVIwgR\np3qzC4ZX1pAiN4yBbzvx6O3C24Zq+6JgzWaeUOLvPW6DUZbpJme5IRSy1TEFkh5vIHmFbiiRHJaA\nVpGTCsHC4SQLkCS1A1ih2J2KIqc+SXwimL3/WLwDJNWiAZb4yTWiVOocNNNbkb8Cn9+D78BPTZv3\nw+fw4SkCT2/jn4Go1sbt2F1Xzigi7VptjL6yvfir0NmAqZfm9/ENwfGRvoqnmRGsrK2qPt1nr4RD\natJ0MrLN7AjAi50KiCpW4soUfYZ2GMwVrugOAd6qzSgU1c2o6CPa9I2wFqL8rM6URON5/Fz7UTxn\nZGU+jnaOJWQCDS6q5ZuTX6Fkgglak78PwxKKIg7Ki3q4UTyZiMqT/VpiX/6lLTcZQXyknN+DMxqv\nlN4U7Z+/4aJ34/csKvsLF9kwp3oLZpohRW5Y1B4GgR/DQLx7Ex8SQjVrklTMlQdml1GW6AZ9B7Pc\nEArZah+BpMeHAHmFbiiRHFauHTFFTioEC4eT1yepiYH47yTohqGxgrE7FUVOfZI2nL4NWLwDJNWi\nia/jjq0xJ6+xuJMd6u3pkaDZgtxlfurFS35EfhNw65nbvxsRHh7gJ8sfexo/CItW/yOYI8trCoYi\n0qBqY/RDlz29K75P6V7zxaf+FDPL/NmkeMvY+UE9mW53t16Cv1suJqUjg8XsXvw11lUFWQpRxUpc\nNSf5pjbD0A6DucKTosb/LROK6mZUDMRs0TfCWojeX78fOTh8+M49hM/Iynwc7TQrfcoEWuSbk1+Z\nZ4IJWpO/v/rSP+sm5YUVUwXcOJ5IRP/w9uWP579452MvjPhyF/pnPr2pUMvpTdE+f3DwDeCMCkrl\nCKIj4HoLZpohRW4YY3obEWZueQifHb73lo+hJJeDXRkqtThJtTcQW4IaZYlu0Hcwyw2hkK32Ymub\nVpZMieWwBLSKnFQIFg4nmU+SwhdfJtANQ2MFY3cqipz6JG04HajFO0BSLhr+1uS6v+NU2tZhh4Yc\nimzIvb3UVuT49RUeC7s0YUq28HslUC0c/6y+RhGB2jFLbYx+sbz4oJ4C8P3cchq0oOq3AWlSKWTm\no4ATEdXmfSrWLNcIQzGsGF7FLfxRsyXG8WDHOSq6E2XPF1YjyjdQcor3kpXV5kPauUbhQKO+rWgE\nTnJKOE45L3DUV6k8bhYvs/BO+qXlv3yYZ3OeW7N73E7R22YH2YzKEVo7ydZbINPkTNuNFHU5U8PB\nmmX5OSSnkaWbkuUEELalq3zm6pC/9hstdJqflSOz1kYF+47EURpnGi9LktyIs8GSo37sVFGZifjZ\nN3OPlPau78jC60XDEvfen8HRVcQp2jrMM3tWOhdbkePXV3j05Kts4csR+Zi5J7riuESdYGpHN7QR\nHBvQ1nifpCvAc3hENr5PdWdG+DQDeFIpZOajoFIR9eZ9IlYVteGqgPSrxtO9HfH52uHaGXoT4yrK\nqS6ioO8KqxFztgMzVH0+pJ1mxadQoFHfAC5JSEwJ9iYaJi8wyX2V5NwyuFk8wd45VM7K9EvLf/rk\nxyjTq9y0Gyl62+y8jMoRWvvJ1puohUymyZm2GynqcSw25wjVLMvvzOSOSti8KBkgkxd+8ewwqtPQ\ndpmQKFntqKRZVo7MWtP8YOF4yeuTtKkRlh7b8XRPJikRXIEE7wBJvWhY4t7TrLStwzwz9buhC1hm\nxzclj/vkK77chv8ego/olhjtjvDFPVaU0UN4USHN7+oJ3R13Zqa3MJxHnzSpO8pcxl/QiiJLZt58\nKETEX7kVB8aa5eqD8Yhg6CLDHXyRG4zsqchTTMMXViPm/OKPI6vLpzsy0E4rFGjUt2MpOmkp4Znx\nQEAlea0qrsAT7J3DJAmk5f/nHXPsLG5lR2S/rN5eRhULna23QKZ51KSoj3jDgZqNya9ss3QDvqMA\nIVuPkRlITFavcLy1VpDuHSmZpOHjtfzYuyNvkh7IrllgXmTh9aJhic/vZ6zStg7LmulHnrjJwezD\n/y0RnyTcHWy85ek9fBUtcXA6q654xa8J8eisA1z/7aFo9rfFKx6Zn5lq0LxOnflRa1IpZOZj0ESr\nENHEmuXqAjk9EYaLDFwnPNEgeyryHNPYwaYrrEY8auZkW46sLp+AdsoaF9ULdAcvBX1nHYrNMLxg\nfGvPjAd8ldSlqrgCb4fRdcOkH6Tl/8xmFuLHswOyX1bv8kJ74gYyzaMmRf1DbzhQszH5lW2WbsB3\nFCBk6zEyA4nJ6smxYyDsVlry+olvY7htP/ZoRXkkXSTZ28HXAEm9aFji3v+2Nz29lbB1WNZMfXFj\nPm7hrVe4Dh+P+cPq6yTzqQvwt1IqHM0jBxD9WCtx7e16AfrIOSp61kCIN/uXeCRONRCptLIXNW5N\nvtmRbtjWpYIhe18lj1UZ3DBPK/3S8r870vz4FHnbFlcsprdEjJuFA8itN+ZIDYnRW6Uun30hY97Y\nRDXK0zUAcVszx2vliidm+6F4GGagOMpJIUmLhiW+qD6gmyjStg7LmqkN7cxW5AYvrSU34DIbo6cZ\nJc1qHrlurHHazSDLv2SOOylzRWzrVn1R61nHeTaPayVJWv7jX81kjtn1zMCkd/kN9qQTbfkZBfSi\nyRK/yQzLVuLWYRkzuW+atRV5BrSoq3bMMhujF81Pvz4G5Jqx5nBvBnkJfwGzmUNs61Z9UetZxyNo\nHtdOksT8n93MErw2OzDh/bdPOL+WXkABvWiyxK/OXE/cOixjdkxs4me2Is9gFnbVBlxmY/RCg+QJ\nY0CuGWsO9WaQ50/kuCh1SWzrVn1R61nHiTaPaydJYv7H6bVXWgXGrYAs8UNrrpuUrcPQImN2ldnE\nz4VL602PeMe+NIPkWWNArhlrDvVmkFeGOS5KXaJt3UoZ8eR61gzjNZrHtZMkMf89Vu1Aq8B5U0CW\nuNyw0nKZuHVYxoz29rKAyjQX9GZeZWzS5o4BuWasObybQT45yHFR6hLvmFbKiibXsyYU/9w8rp0k\nifnv02pHWgXOlwKyxHv4ByXWgc9kk7YOc83svb0ssOTmcbNjX7JN2sTmkevGGufdEPJzcQ/lrpgd\n08rZqdn1rOMex4BrJUlq/sf5tVdaBcatgCrxGx03+AsyaVuHOWY9axM/By6xc9LsmJVokTqteeS6\nscaZN4M81dwDSrP5XZx09MpyLesorL0lX3xSuStWkiTnfzkP7exWgeYU0CUu/uLcHAupW4c5ZjPW\nJn4GK711xGzAlW6UNLN55Lqxxmk3gzy/HvdQ7sq82fyunKGcXc867nAMuFaSJOd/nGB7pVVgvAro\nEl+2Kz196zDHzN7bqwrpe80GXFXMc2yaR64ba5xsM8jXOT+J496Kr5gd04rn+jPqWft4NDIGXJMk\n6flPdNpzq8D5VkCXuPr/wQLOF3ZpcEq28Am82blN/7diNKM9T4oC3RsmhcmFziM//y/06Fr+F6wC\nXOLXR0Iwf7gs/iRf7VvFO3/hXhYRs3b4NVWguS9LXtMwJsB5Qf5PAMOWwutSAS7x6Y1I/PfR+G3Y\nUJtr3UFD+B/bbJh225oYBf54Yphc8ETy8/+CD68N4AJVwJT4NZEIeGeDHZyg9q3iZMaRmFkErR0+\nHwpMjc6Hl9eHj4L8f32I0EY5aQpYJT69FibX38mO4+9MmSNmZma0rfOuwK2NPZ8879QnzmFB/k8c\n35bQ60IBVeL/Bxn5MzkIw2ArAAAAAElFTkSuQmCC\n",
-      "text/latex": [
-       "$$\\left ( - \\frac{1}{M{\\left (x,y \\right )}} \\left(- \\frac{4}{h^{2}} p{\\left (x,y,t \\right )} + \\frac{1}{h^{2}} p{\\left (x,- h + y,t \\right )} + \\frac{1}{h^{2}} p{\\left (x,h + y,t \\right )} + \\frac{1}{h^{2}} p{\\left (- h + x,y,t \\right )} + \\frac{1}{h^{2}} p{\\left (h + x,y,t \\right )}\\right) - D{\\left (x,y,t \\right )} - \\frac{2}{s^{2}} p{\\left (x,y,t \\right )} + \\frac{1}{s^{2}} p{\\left (x,y,- s + t \\right )} + \\frac{1}{s^{2}} p{\\left (x,y,s + t \\right )}, \\quad \\frac{1}{h^{2} M{\\left (x,y \\right )}} \\left(h^{2} \\left(s^{2} D{\\left (x,y,t \\right )} + 2 p{\\left (x,y,t \\right )} - p{\\left (x,y,s + t \\right )}\\right) M{\\left (x,y \\right )} - 4 s^{2} p{\\left (x,y,t \\right )} + s^{2} p{\\left (x,- h + y,t \\right )} + s^{2} p{\\left (x,h + y,t \\right )} + s^{2} p{\\left (- h + x,y,t \\right )} + s^{2} p{\\left (h + x,y,t \\right )}\\right)\\right )$$"
-      ],
-      "text/plain": [
-       "⎛    4⋅p(x, y, t)   p(x, -h + y, t)   p(x, h + y, t)   p(-h + x, y, t)   p(h +\n",
-       "⎜  - ──────────── + ─────────────── + ────────────── + ─────────────── + ─────\n",
-       "⎜          2                2                2                 2              \n",
-       "⎜         h                h                h                 h               \n",
-       "⎜- ───────────────────────────────────────────────────────────────────────────\n",
-       "⎜                                        M(x, y)                              \n",
-       "⎝                                                                             \n",
-       "\n",
-       " x, y, t)                                                                     \n",
-       "─────────                                                                     \n",
-       "  2                                                                        2 ⎛\n",
-       " h                       2⋅p(x, y, t)   p(x, y, -s + t)   p(x, y, s + t)  h ⋅⎝\n",
-       "───────── - D(x, y, t) - ──────────── + ─────────────── + ──────────────, ────\n",
-       "                               2                2                2            \n",
-       "                              s                s                s             \n",
-       "\n",
-       "                                                                              \n",
-       "                                                                              \n",
-       " 2                                           ⎞              2               2 \n",
-       "s ⋅D(x, y, t) + 2⋅p(x, y, t) - p(x, y, s + t)⎠⋅M(x, y) - 4⋅s ⋅p(x, y, t) + s ⋅\n",
-       "──────────────────────────────────────────────────────────────────────────────\n",
-       "                                                                       2      \n",
-       "                                                                      h ⋅M(x, \n",
-       "\n",
-       "                                                                            ⎞\n",
-       "                                                                            ⎟\n",
-       "                   2                   2                    2               ⎟\n",
-       "p(x, -h + y, t) + s ⋅p(x, h + y, t) + s ⋅p(-h + x, y, t) + s ⋅p(h + x, y, t)⎟\n",
-       "────────────────────────────────────────────────────────────────────────────⎟\n",
-       "                                                                            ⎟\n",
-       "y)                                                                          ⎠"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "wave_equationA = dtt- 1/m*(dxx+dyy) - D(x,y,t)\n",
     "stencilA = solve(wave_equationA,p(x,y,t-s))[0]\n",
@@ -436,7 +374,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -459,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -477,7 +415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -491,23 +429,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "source() takes 1 positional argument but 3 were given",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-30-5ae7f52df6be>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[0;32m      2\u001b[0m \u001b[0mterm1\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;36m0\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      3\u001b[0m \u001b[1;32mfor\u001b[0m \u001b[0mti\u001b[0m \u001b[1;32min\u001b[0m \u001b[0mrange\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;36m1\u001b[0m\u001b[1;33m,\u001b[0m\u001b[0mnt\u001b[0m\u001b[1;33m-\u001b[0m\u001b[1;36m1\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 4\u001b[1;33m     \u001b[0mterm1\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mterm1\u001b[0m\u001b[1;33m+\u001b[0m\u001b[0msrca\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mti\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0msource\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;36m0.0\u001b[0m\u001b[1;33m,\u001b[0m\u001b[1;36m0.0\u001b[0m\u001b[1;33m,\u001b[0m\u001b[0mti\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0mtstep\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m      5\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      6\u001b[0m \u001b[0mterm2\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mLA\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mnorm\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mrec\u001b[0m\u001b[1;33m,\u001b[0m\u001b[0mord\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;36m2\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m**\u001b[0m\u001b[1;36m2\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;31mTypeError\u001b[0m: source() takes 1 positional argument but 3 were given"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Actual adjoint test\n",
     "term1=0\n",
@@ -666,25 +592,34 @@
    },
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
On a smaller grid (14 x 14 x 14), the run time went from 231 seconds to 5 seconds because of this change. 

The compiled function couldn't accept parameters as p(x,y,z) (as far as I understood the problem) so I had to make a variable for each array access. Sorry for dirtying up your code. Will work on beautifying the code again, however I want your feedback on whether its producing equivalent results. I compared the numerical output at the last time step and its the same (x,y) matrix. 

This version doesn't contain any vectorisation. Further speedups should be expected once that is done. 

Edit: The change suggested here uses the `autowrap` function to use a C-compiled version of the stencil function. The speedup observed after this change was measured on a reduced grid as described above. 
